### PR TITLE
updating the readme to not point at bcas

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Casual script for Kingdom of Loathing.
 
-`svn checkout https://github.com/phulin/bean-casual/branches/main/KoLmafia`
+`svn checkout https://github.com/chunkinaround/bean-casual/branches/ts/KoLmafia`


### PR DESCRIPTION
Just noticed your readme is pointing people to bean's script rather than yours.